### PR TITLE
[MRG] ComplementNB with class priors when computing joint log-likelihoods (Trac : #14523, #14444)

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -904,13 +904,14 @@ class ComplementNB(_BaseDiscreteNB):
             feature_log_prob = -logged
         self.feature_log_prob_ = feature_log_prob
 
-    def _joint_log_likelihood(self, X):
-        """Calculate the class scores for the samples in X."""
+    def _joint_log_likelihood(self, X):	    
+        """Calculate the class scores for the samples in X."""	       
+        check_is_fitted(self, "classes_")
+        X = check_array(X, accept_sparse="csr")
         jll = safe_sparse_dot(X, self.feature_log_prob_.T)
-        if len(self.classes_) == 1:
+        if self.fit_prior == True :
             jll += self.class_log_prior_
         return jll
-
 
 class BernoulliNB(_BaseDiscreteNB):
     """Naive Bayes classifier for multivariate Bernoulli models.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes issue : #14444
Follows PR : #14523


#### What does this implement/fix? Explain your changes.

Permits the use of the priors in the ComplementNB by adding the possibility to chose if we need them or not.
('if self.fit_prior == True')
